### PR TITLE
fix: resolve Claude code review OIDC authentication failures

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -46,6 +46,7 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
           # model: "claude-opus-4-20250514"


### PR DESCRIPTION
## Summary
Fixes the persistent OIDC authentication failures in Claude code review workflow on push events.

## Problem
Push events consistently failed with "Invalid OIDC token" error while pull_request events worked fine. This was due to different GitHub context and permissions between event types.

## Solution
- Added `github_token: ${{ secrets.GITHUB_TOKEN }}` parameter to bypass OIDC authentication
- Uses standard GitHub token authentication instead of OIDC token exchange
- Maintains all existing functionality for both PR and push events

## Testing
This fix addresses the authentication issue root cause identified in the workflow logs.

🤖 Generated with [Claude Code](https://claude.ai/code)